### PR TITLE
shortcuts: fix issue where jak 2 shortcut was saving with jak 1's ID

### DIFF
--- a/main.py
+++ b/main.py
@@ -288,7 +288,7 @@ class Plugin:
                         )
                         % 1_000_000_000
                     ) * -1
-                    d["shortcuts"]["opengoal-jak1"] = {
+                    d["shortcuts"]["opengoal-jak2"] = {
                         "appid": app_id,
                         "AppName": "OpenGOAL - Jak 2",
                         "Exe": os.path.join(


### PR DESCRIPTION
This may fix https://github.com/open-goal/decky-plugin/issues/6 and https://github.com/open-goal/decky-plugin/issues/7